### PR TITLE
Use SpringBoot dependency injection for database encryption password

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,11 @@
         <artifactId>liquibase-core</artifactId>
         <version>${liquibase.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.hibernate.validator</groupId>
+        <artifactId>hibernate-validator</artifactId>
+        <version>7.0.1.Final</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/src/main/java/eu/interop/federationgateway/config/DbEncryption.java
+++ b/src/main/java/eu/interop/federationgateway/config/DbEncryption.java
@@ -1,0 +1,22 @@
+package eu.interop.federationgateway.config;
+
+import eu.interop.federationgateway.dbencryption.DbEncryptionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class DbEncryption {
+  @Value("${efgs.dbencryption.password:}")
+  private String dbEncryptionPassword;
+
+  @Bean
+  public DbEncryptionService dbEncryptionService() {
+    return DbEncryptionService.getInstance(dbEncryptionPassword);
+  }
+}

--- a/src/main/java/eu/interop/federationgateway/dbencryption/DbEncryptionByteArrayConverter.java
+++ b/src/main/java/eu/interop/federationgateway/dbencryption/DbEncryptionByteArrayConverter.java
@@ -26,13 +26,17 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.persistence.AttributeConverter;
 import javax.persistence.PersistenceException;
+import org.springframework.beans.factory.annotation.Autowired;
+
 
 public class DbEncryptionByteArrayConverter implements AttributeConverter<byte[], String> {
+  @Autowired
+  DbEncryptionService dbEncryptionService;
 
   @Override
   public String convertToDatabaseColumn(byte[] s) {
     try {
-      return DbEncryptionService.getInstance().encryptByteArray(s);
+      return dbEncryptionService.encryptByteArray(s);
     } catch (InvalidAlgorithmParameterException | InvalidKeyException 
             | BadPaddingException | IllegalBlockSizeException e) {
       throw new PersistenceException(e);
@@ -42,7 +46,7 @@ public class DbEncryptionByteArrayConverter implements AttributeConverter<byte[]
   @Override
   public byte[] convertToEntityAttribute(String s) {
     try {
-      return DbEncryptionService.getInstance().decryptByteArray(s);
+      return dbEncryptionService.decryptByteArray(s);
     } catch (InvalidAlgorithmParameterException | InvalidKeyException 
             | BadPaddingException | IllegalBlockSizeException e) {
       throw new PersistenceException(e);

--- a/src/main/java/eu/interop/federationgateway/dbencryption/DbEncryptionIntConverter.java
+++ b/src/main/java/eu/interop/federationgateway/dbencryption/DbEncryptionIntConverter.java
@@ -26,13 +26,16 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.persistence.AttributeConverter;
 import javax.persistence.PersistenceException;
+import org.springframework.beans.factory.annotation.Autowired;
 
 public class DbEncryptionIntConverter implements AttributeConverter<Integer, String> {
+  @Autowired
+  DbEncryptionService dbEncryptionService;
 
   @Override
   public String convertToDatabaseColumn(Integer s) {
     try {
-      return DbEncryptionService.getInstance().encryptInteger(s);
+      return dbEncryptionService.encryptInteger(s);
     } catch (InvalidAlgorithmParameterException | InvalidKeyException 
             | BadPaddingException | IllegalBlockSizeException e) {
       throw new PersistenceException(e);
@@ -42,7 +45,7 @@ public class DbEncryptionIntConverter implements AttributeConverter<Integer, Str
   @Override
   public Integer convertToEntityAttribute(String s) {
     try {
-      return DbEncryptionService.getInstance().decryptInteger(s);
+      return dbEncryptionService.decryptInteger(s);
     } catch (InvalidAlgorithmParameterException | InvalidKeyException 
             | BadPaddingException | IllegalBlockSizeException e) {
       throw new PersistenceException(e);

--- a/src/main/java/eu/interop/federationgateway/dbencryption/DbEncryptionReportTypeConverter.java
+++ b/src/main/java/eu/interop/federationgateway/dbencryption/DbEncryptionReportTypeConverter.java
@@ -27,13 +27,16 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.persistence.AttributeConverter;
 import javax.persistence.PersistenceException;
+import org.springframework.beans.factory.annotation.Autowired;
 
 public class DbEncryptionReportTypeConverter implements AttributeConverter<DiagnosisKeyPayload.ReportType, String> {
-
+  @Autowired
+  DbEncryptionService dbEncryptionService;
+  
   @Override
   public String convertToDatabaseColumn(DiagnosisKeyPayload.ReportType s) {
     try {
-      return DbEncryptionService.getInstance().encryptString(s.name());
+      return dbEncryptionService.encryptString(s.name());
     } catch (InvalidAlgorithmParameterException | InvalidKeyException 
             | BadPaddingException | IllegalBlockSizeException e) {
       throw new PersistenceException(e);
@@ -43,7 +46,7 @@ public class DbEncryptionReportTypeConverter implements AttributeConverter<Diagn
   @Override
   public DiagnosisKeyPayload.ReportType convertToEntityAttribute(String s) {
     try {
-      return DiagnosisKeyPayload.ReportType.valueOf(DbEncryptionService.getInstance().decryptString(s));
+      return DiagnosisKeyPayload.ReportType.valueOf(dbEncryptionService.decryptString(s));
     } catch (InvalidAlgorithmParameterException | InvalidKeyException 
             | BadPaddingException | IllegalBlockSizeException e) {
       throw new PersistenceException(e);

--- a/src/main/java/eu/interop/federationgateway/dbencryption/DbEncryptionService.java
+++ b/src/main/java/eu/interop/federationgateway/dbencryption/DbEncryptionService.java
@@ -36,9 +36,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.encrypt.AesBytesEncryptor;
 
 @Slf4j
-public class DbEncryptionService {
 
-  private static final String PASSWORD_PROPERTY_NAME = "efgs_dbencryption_password";
+public class DbEncryptionService {
   private static final Charset CHARSET = StandardCharsets.UTF_8;
   private static DbEncryptionService instance;
   private final Cipher cipher;
@@ -48,12 +47,8 @@ public class DbEncryptionService {
    * Constructor for DbEncryptionService.
    * Initializes Cipher with ciphersuite configured in application properties.
    */
-  private DbEncryptionService() {
+  private DbEncryptionService(String dbEncryptionPassword) {
     cipher = AesBytesEncryptor.CipherAlgorithm.CBC.createCipher();
-
-    String dbEncryptionPassword = System.getenv().containsKey(PASSWORD_PROPERTY_NAME)
-      ? System.getenv(PASSWORD_PROPERTY_NAME)
-      : System.getProperty(PASSWORD_PROPERTY_NAME);
 
     if (dbEncryptionPassword != null) {
       int passwordLength = dbEncryptionPassword.length();
@@ -72,9 +67,9 @@ public class DbEncryptionService {
    * Returns an instance of Singleton-DbEncryptionService.
    * @return The DbEncryptionService instance
    */
-  public static DbEncryptionService getInstance() {
+  public static DbEncryptionService getInstance(String dbEncryptionPassword) {
     if (DbEncryptionService.instance == null) {
-      DbEncryptionService.instance = new DbEncryptionService();
+      DbEncryptionService.instance = new DbEncryptionService(dbEncryptionPassword);
     }
 
     return instance;

--- a/src/main/java/eu/interop/federationgateway/dbencryption/DbEncryptionStringConverter.java
+++ b/src/main/java/eu/interop/federationgateway/dbencryption/DbEncryptionStringConverter.java
@@ -26,13 +26,17 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.persistence.AttributeConverter;
 import javax.persistence.PersistenceException;
+import org.springframework.beans.factory.annotation.Autowired;
 
 public class DbEncryptionStringConverter implements AttributeConverter<String, String> {
+
+  @Autowired
+  DbEncryptionService dbEncryptionService;
 
   @Override
   public String convertToDatabaseColumn(String s) {
     try {
-      return DbEncryptionService.getInstance().encryptString(s);
+      return dbEncryptionService.encryptString(s);
     } catch (InvalidAlgorithmParameterException | InvalidKeyException 
             | BadPaddingException | IllegalBlockSizeException e) {
       throw new PersistenceException(e);
@@ -42,7 +46,7 @@ public class DbEncryptionStringConverter implements AttributeConverter<String, S
   @Override
   public String convertToEntityAttribute(String s) {
     try {
-      return DbEncryptionService.getInstance().decryptString(s);
+      return dbEncryptionService.decryptString(s);
     } catch (InvalidAlgorithmParameterException | InvalidKeyException 
             | BadPaddingException | IllegalBlockSizeException e) {
       throw new PersistenceException(e);


### PR DESCRIPTION
This PR updates hibernate-validator to the newest version to pass CVE-2020-10693.

Further, it changes the injection of the database encryption password from manual (via System.getProperty) to a Bean. This lets SpringBoot resolve the variables and allows variable substitution, which we need in order to use the secret injected by CloudFoundry.